### PR TITLE
desc_dict and get_desc

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Catch22 = "acdeb78f-3d39-4310-8fdf-6d75c17c6d5a"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "5561e46e-99f6-4d08-aa13-3565f6e795b3"
 authors = ["Eduard I. STAN", "Giovanni PAGLIARINI"]
 version = "0.1.0"
 
+[deps]
+Catch22 = "acdeb78f-3d39-4310-8fdf-6d75c17c6d5a"
+
 [compat]
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Catch22 = "acdeb78f-3d39-4310-8fdf-6d75c17c6d5a"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 julia = "1"

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -3,6 +3,11 @@ module SoleFunctions
 using Statistics
 using Catch22
 
+# -------------------------------------------------------------
+# exports
+export get_desc
+
+# taken from https://github.com/aclai-lab/SoleBase.jl/blob/dev/src/data/dataset/describe.jl
 const desc_dict = Dict{Symbol,Function}(
     :mean => mean,
     :min => minimum,
@@ -18,4 +23,35 @@ const auto_desc_by_dim = Dict{Integer,Vector{Symbol}}(
     1 => [:mean, :min, :max, :quantile_1, :median, :quantile_3]
 )
 
+""" 
+    get_desc(descfun, values)
+
+Apply functions represented by `descfun` to `values`.\n
+Return a dictionary containing the associations :symbol -> value (e.g :mean -> 3.5)
+
+## PARAMETERS
+* `descfun` is a `Vector` of Symbols which are mapped to specific functions.
+* `values` are a `Vector` of Numbers on which the description functions are applied.
+
+## EXAMPLE
+```julia-repl 
+julia> desc_syms = [:mean, :min, :max]
+julia> values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+julia> values_description = get_desc(desc_syms, values)
+Dict{Symbol, Real}(:max => 10, :mean => 5.5, :min => 1)
+```
+"""
+function get_desc(descfun::Vector{Symbol}, values::Vector{<:Number})
+    # a symbol is valid only if it is defined in desc_dict
+    for df in descfun
+        @assert df in keys(desc_dict) "`$(df)` is not a valid descriptor"
+    end
+
+    ans_dict = Dict{Symbol, Real}()
+    apply(f, x) = f(x)
+    [push!(ans_dict, df => apply(desc_dict[df], values)) for df in descfun]
+
+    return ans_dict
 end
+
+end # module

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -1,5 +1,21 @@
 module SoleFunctions
 
-# Write your package code here.
+using Statistics
+using Catch22
+
+const desc_dict = Dict{Symbol,Function}(
+    :mean => mean,
+    :min => minimum,
+    :max => maximum,
+    :median => median,
+    :quantile_1 => (q_1 = x -> quantile(x, 0.25)),
+    :quantile_3 =>(q_3 = x -> quantile(x, 0.75)),
+    # allow catch22 desc
+    (getnames(catch22) .=> catch22)...
+)
+
+const auto_desc_by_dim = Dict{Integer,Vector{Symbol}}(
+    1 => [:mean, :min, :max, :quantile_1, :median, :quantile_3]
+)
 
 end

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -31,7 +31,7 @@ Return a dictionary containing the associations :symbol -> value (e.g :mean -> 3
 
 ## PARAMETERS
 * `descfun` is a `Vector` of Symbols which are mapped to specific functions.
-* `values` are a `Vector` of Numbers on which the description functions are applied.
+* `values` is a `Vector` of Numbers on which the description functions are applied.
 
 ## EXAMPLE
 ```julia-repl 

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -8,7 +8,6 @@ using Catch22
 export get_desc
 
 # taken from https://github.com/aclai-lab/SoleBase.jl/blob/dev/src/data/dataset/describe.jl
-
 const desc_dict = Dict{Symbol,Function}(
     :mean => mean,
     :min => minimum,

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -3,6 +3,7 @@ module SoleFunctions
 using Statistics
 using Catch22
 
+
 const desc_dict = Dict{Symbol,Function}(
     :mean => mean,
     :min => minimum,
@@ -17,5 +18,6 @@ const desc_dict = Dict{Symbol,Function}(
 const auto_desc_by_dim = Dict{Integer,Vector{Symbol}}(
     1 => [:mean, :min, :max, :quantile_1, :median, :quantile_3]
 )
+
 
 end

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -23,7 +23,7 @@ const desc_dict = Dict{Symbol,Function}(
 const dim_desc = Dict{Integer,Vector{Symbol}}(
     # TODO add default functions for other dimensions
     0 => [:mean, :min, :max],
-    1 => [:min, :max, :quantile_1, :median, :quantile_3],
+    1 => [:mean,:min, :max, :quantile_1, :median, :quantile_3],
     2 => [:mean, :min, :max, :quantile_1, :median, :quantile_3]
 )
 

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -5,9 +5,9 @@ using Catch22
 
 # -------------------------------------------------------------
 # exports
-export get_desc
+export apply_descriptors
 
-# taken from https://github.com/aclai-lab/SoleBase.jl/blob/dev/src/data/dataset/describe.jl
+# function dictionary
 const desc_dict = Dict{Symbol,Function}(
     :mean => mean,
     :min => minimum,
@@ -19,39 +19,80 @@ const desc_dict = Dict{Symbol,Function}(
     (getnames(catch22) .=> catch22)...
 )
 
-const auto_desc_by_dim = Dict{Integer,Vector{Symbol}}(
-    1 => [:mean, :min, :max, :quantile_1, :median, :quantile_3]
+# default functions by dimension
+const dim_desc = Dict{Integer,Vector{Symbol}}(
+    # TODO add default functions for other dimensions
+    0 => [:mean, :min, :max],
+    1 => [:min, :max, :quantile_1, :median, :quantile_3],
+    2 => [:mean, :min, :max, :quantile_1, :median, :quantile_3]
 )
 
 """ 
-    get_desc(descfun, values)
+    apply_descriptors(descriptors, values)
 
-Evaluate `descfun` with `values`.\n
-Return a dictionary containing the associations :symbol -> value (e.g :mean -> 3.5)
+Evaluate `descriptors` with `values`.\n
+Return a dictionary containing the associations descriptor -> value
 
 ## PARAMETERS
-* `descfun` is a `Vector` of Symbols which are mapped to specific functions.
+* `descriptors` is a `Vector` containing both Symbols and Functions.
 * `values` is a `Vector` of Numbers on which the description functions are applied.
 
 ## EXAMPLE
 ```julia-repl 
-julia> desc_syms = [:mean, :min, :max]
+julia> desc_syms = [:mean, :min, maximum]
 julia> values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-julia> values_description = get_desc(desc_syms, values)
-Dict{Symbol, Real}(:max => 10, :mean => 5.5, :min => 1)
+julia> values_description = descriptors(desc_syms, values)
+Dict{Symbol, Real}(:max => 10, :mean => 5.5, :min => 1)\n
 ```
+
+    apply_descriptors(values)
+Depending on `values` dimension, apply default functions.
+
+# TODO - show to the user which functions are applied
+
+## PARAMETERS
+* `values` is a `Vector` of Numbers on which the description functions are applied.
+\n
 """
-function get_desc(descfun::Vector{Symbol}, values::Vector{<:Number})
-    # a symbol is valid only if it is defined in desc_dict
-    for df in descfun
-        @assert df in keys(desc_dict) "`$(df)` is not a valid descriptor"
+function apply_descriptors(descriptors::Vector{Any},  values::Array{<:Number})
+    # descriptors must contain only Function and Symbol types
+    try
+        convert(Vector{Union{Function, Symbol}}, descriptors)
+    catch e
+        @error "Argument descriptors must contain only Function and Symbol types"
     end
 
-    ans_dict = Dict{Symbol, Real}()
-    apply(f, x) = f(x)
-    [push!(ans_dict, df => apply(desc_dict[df], values)) for df in descfun]
+    # returned dictionary
+    answer = Dict{Union{Symbol, Function}, Real}()
 
-    return ans_dict
+    # all description functions are applied, results are stored in a new "answer" entry
+    for desc in descriptors
+        if isa(desc, Symbol)
+            push!(answer, desc => desc_dict[desc](values))
+        else
+            push!(answer, desc => desc(values))
+        end
+    end
+
+    return answer
+end
+
+function apply_descriptors(descriptors::Vector{Symbol}, values::Array{<:Number})
+    answer = Dict{Symbol, Real}()
+    [push!(answer, desc => desc_dict[desc](values)) for desc in descriptors]
+    return answer
+end
+
+function apply_descriptors(descriptor::Symbol, values::Array{<:Number})
+    return apply_descriptors( [descriptor] , values)
+end
+
+function apply_descriptors(values::Array{<:Number})
+    dims = ndims(values)
+    return apply_descriptors( dim_desc[dims] , values)
 end
 
 end # module
+
+#da scrivere nella pull request:
+#bisogna stare attenti ai tipi in apply descriptors

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -26,7 +26,7 @@ const auto_desc_by_dim = Dict{Integer,Vector{Symbol}}(
 """ 
     get_desc(descfun, values)
 
-Apply functions represented by `descfun` to `values`.\n
+Evaluate `descfun` with `values`.\n
 Return a dictionary containing the associations :symbol -> value (e.g :mean -> 3.5)
 
 ## PARAMETERS

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -23,8 +23,8 @@ const desc_dict = Dict{Symbol,Function}(
 const dim_desc = Dict{Integer,Vector{Symbol}}(
     # TODO add default functions for other dimensions
     0 => [:mean, :min, :max],
-    1 => [:mean,:min, :max, :quantile_1, :median, :quantile_3],
-    2 => [:mean, :min, :max, :quantile_1, :median, :quantile_3]
+    1 => [:mean, :min, :max, :quantile_1, :median, :quantile_3],
+    2 => [:mean, :min, :max, :median]
 )
 
 """ 
@@ -84,12 +84,16 @@ function apply_descriptors(descriptors::Vector{Symbol}, values::Array{<:Number})
 end
 
 function apply_descriptors(descriptor::Symbol, values::Array{<:Number})
-    return apply_descriptors( [descriptor] , values)
+    return apply_descriptors([descriptor], values)
+end
+
+function apply_descriptors(values::Number)
+    return apply_descriptors(dim_desc[0], [values])
 end
 
 function apply_descriptors(values::Array{<:Number})
     dims = ndims(values)
-    return apply_descriptors( dim_desc[dims] , values)
+    return apply_descriptors(dim_desc[dims], values)
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,5 +2,26 @@ using SoleFunctions
 using Test
 
 @testset "SoleFunctions.jl" begin
-    # Write your tests here.
+
+    test1 = [5,3,7,9,10,921.231,1,32,1323,12.3,12.2,212]
+    min = minimum(test1)
+    max = maximum(test1)
+    mean = mean(test1)
+    median = median(test1)
+    q_1 = quantile(test1, 0.25)
+    q_3 = quantile(test1, 0.75)
+    desc1 = Dict{Symbol, Real}(:min => min, :max => max, :mean => mean, :median => median, :quantile_1 => q_1, :quantile_3 => q_3)
+    
+    # general test (both Symbols and Functions)
+    @test_throws MethodError apply_descriptors( ["minimum", minimum, :min], [1,2,3])
+
+    # single Symbol test
+
+    # single Function test
+
+    # default test
+
+    #@test apply_descriptors(test1) == desc1
+
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,18 @@
 using SoleFunctions
+using Statistics
 using Test
 
 @testset "SoleFunctions.jl" begin
-
     test1 = [5,3,7,9,10,921.231,1,32,1323,12.3,12.2,212]
+    
     min = minimum(test1)
     max = maximum(test1)
-    mean = mean(test1)
-    median = median(test1)
+    media = mean(test1)
+    mediana = median(test1)
     q_1 = quantile(test1, 0.25)
     q_3 = quantile(test1, 0.75)
-    desc1 = Dict{Symbol, Real}(:min => min, :max => max, :mean => mean, :median => median, :quantile_1 => q_1, :quantile_3 => q_3)
+
+    desc1 = Dict{Symbol, Real}(:mean => media, :min => min, :max => max, :median => mediana, :quantile_1 => q_1, :quantile_3 => q_3)
     
     # general test (both Symbols and Functions)
     @test_throws MethodError apply_descriptors( ["minimum", minimum, :min], [1,2,3])
@@ -18,8 +20,10 @@ using Test
     # single Symbol test
 
     # single Function test
+    @test 
 
     # default test
+    @test apply_descriptors(test1) == desc1
 
     #@test apply_descriptors(test1) == desc1
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,31 +1,37 @@
 using SoleFunctions
 using Statistics
+using Random
 using Test
 
-@testset "SoleFunctions.jl" begin
-    test1 = [5,3,7,9,10,921.231,1,32,1323,12.3,12.2,212]
-    
-    min = minimum(test1)
-    max = maximum(test1)
-    media = mean(test1)
-    mediana = median(test1)
-    q_1 = quantile(test1, 0.25)
-    q_3 = quantile(test1, 0.75)
+rng = MersenneTwister(123)
 
-    desc1 = Dict{Symbol, Real}(:mean => media, :min => min, :max => max, :median => mediana, :quantile_1 => q_1, :quantile_3 => q_3)
-    
+@testset "SoleFunctions.jl" begin
+
+    # adimensional test input and expected output
+    t0 = 42
+    desc0 = Dict{Symbol, Real}(:mean => t0, :min => t0, :max => t0)
+
+    # one dimensional test input and expected output
+    t1 = randn(rng, 100)
+    desc1 = Dict{Symbol, Real}(:min => minimum(t1), :max => maximum(t1), :mean => mean(t1), :median => median(t1), :quantile_1 => quantile(t1, 0.25), :quantile_3 => quantile(t1, 0.75))
+
+    # two dimensional test input and expected output
+    t2 = randn(rng, 100, 2)
+    desc2 = Dict{Symbol, Real}(:min => minimum(t2), :max => maximum(t2), :mean => mean(t2), :median => median(t2))
+
     # general test (both Symbols and Functions)
     @test_throws MethodError apply_descriptors( ["minimum", minimum, :min], [1,2,3])
 
+    @test apply_descriptors([:mean, minimum, maximum, :quantile_1], t1) == Dict{Union{Function, Symbol}, Real}(:mean => mean(t1), minimum => minimum(t1), maximum => maximum(t1), :quantile_1 => quantile(t1, 0.25))
+    @test apply_descriptors([:mean], t2) == Dict{Symbol, Real}(:mean => mean(t2))
     # single Symbol test
 
     # single Function test
-    @test 
 
     # default test
-    @test apply_descriptors(test1) == desc1
-
-    #@test apply_descriptors(test1) == desc1
+    @test apply_descriptors(t0) == desc0
+    @test apply_descriptors(t1) == desc1
+    @test apply_descriptors(t2) == desc2
 
 
 end


### PR DESCRIPTION
Addedd desc_dict, get_desc.
desc_dict associates symbols to descriptive functions (those in catch22 are included).
get_desc it's an utility function used to apply all the specified description functions to a vector of numbers.