### PR TITLE
𝒮, 𝒟 and apply_descriptors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Catch22 = "acdeb78f-3d39-4310-8fdf-6d75c17c6d5a"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "5561e46e-99f6-4d08-aa13-3565f6e795b3"
 authors = ["Eduard I. STAN", "Giovanni PAGLIARINI"]
 version = "0.1.0"
 
+[deps]
+Catch22 = "acdeb78f-3d39-4310-8fdf-6d75c17c6d5a"
+
 [compat]
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Catch22 = "acdeb78f-3d39-4310-8fdf-6d75c17c6d5a"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 julia = "1"

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -15,14 +15,12 @@ const 𝒮 = Dict{Symbol,Function}(
     :median => median,
     :quantile_1 => (q_1 = x -> quantile(x, 0.25)),
     :quantile_3 =>(q_3 = x -> quantile(x, 0.75)),
-    # allow catch22 desc
+    # catch22 descriptors
     (getnames(catch22) .=> catch22)...
 )
 
 # default functions by dimension
 const 𝒟 = Dict{Integer,Vector{Symbol}}(
-    # TODO manage 0, 2 and higher dimensions.
-    0 => [:max, :mean, :min],
     1 => [:max, :mean, :min, :median, :quantile_1, :quantile_3, getnames(catch22)...],
     2 => [:max, :mean, :median, :min]
 )
@@ -52,9 +50,7 @@ Dict{Union{Function, Symbol}, Number}(:mean => 2.5, :min => 1)\n\n
 ```
 
     apply_descriptors(values)
-Evaluate default descriptors with values, based on values dimension
-
-# TODO - Show 𝒟 content
+Evaluate default descriptors with values, based on values dimension.
 """
 function apply_descriptors(values::Array{<:Number}, symbols::Array{Symbol})
     output = Dict{Union{Symbol, Function}, Number}()

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -3,6 +3,11 @@ module SoleFunctions
 using Statistics
 using Catch22
 
+# -------------------------------------------------------------
+# exports
+export get_desc
+
+# taken from https://github.com/aclai-lab/SoleBase.jl/blob/dev/src/data/dataset/describe.jl
 const desc_dict = Dict{Symbol,Function}(
     :mean => mean,
     :min => minimum,
@@ -18,4 +23,35 @@ const auto_desc_by_dim = Dict{Integer,Vector{Symbol}}(
     1 => [:mean, :min, :max, :quantile_1, :median, :quantile_3]
 )
 
+""" 
+    get_desc(descfun, values)
+
+Apply functions represented by `descfun` to `values`.\n
+Return a dictionary containing the associations :symbol -> value (e.g :mean -> 3.5)
+
+## PARAMETERS
+* `descfun` is a `Vector` of Symbols which are mapped to specific functions.
+* `values` are a `Vector` of Numbers on which the description functions are applied.
+
+## EXAMPLE
+```julia-repl 
+julia> desc_syms = [:mean, :min, :max]
+julia> values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+julia> values_description = get_desc(desc_syms, values)
+Dict{Symbol, Real}(:max => 10, :mean => 5.5, :min => 1)
+```
+"""
+function get_desc(descfun::Vector{Symbol}, values::Vector{<:Number})
+    # a symbol is valid only if it is defined in desc_dict
+    for df in descfun
+        @assert df in keys(desc_dict) "`$(df)` is not a valid descriptor"
+    end
+
+    ans_dict = Dict{Symbol, Real}()
+    apply(f, x) = f(x)
+    [push!(ans_dict, df => apply(desc_dict[df], values)) for df in descfun]
+
+    return ans_dict
 end
+
+end # module

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -65,8 +65,6 @@ function apply_descriptors(values::Array{<:Number}, symbols::Array{Symbol})
     return output
 end
 
-# TODO: add documentation
-# Eduard 11 Apr 2022
 """
     apply_descriptors(values,symbol)
 
@@ -84,8 +82,6 @@ function apply_descriptors(values::Array{<:Number}, symbol::Symbol)
     return apply_descriptors(values, [symbol])
 end
 
-# TODO: add documentation
-# Eduard 11 Apr 2022
 """
     apply_descriptors(values,functions)
 
@@ -106,8 +102,6 @@ function apply_descriptors(values::Array{<:Number}, functions::Array{<:Function}
     return output
 end
 
-# TODO: add documentation
-# Eduard 11 Apr 2022
 """
     apply_descriptors(values,function)
 
@@ -125,8 +119,6 @@ function apply_descriptors(values::Array{<:Number}, f::Function)
     return apply_descriptors(values, [f])
 end
 
-# TODO: add documentation
-# Eduard 11 Apr 2022
 """
     apply_descriptors(values, symbols, functions)
 Evaluate `symbols` and `functions` on `values`.\n
@@ -151,8 +143,6 @@ function apply_descriptors(
     return output
 end
 
-# TODO: add documentation
-# Eduard 11 Apr 2022
 """
     apply_descriptors(values, functions, symbols)
 Evaluate `symbols` and `functions` on `values`.\n
@@ -175,8 +165,6 @@ function apply_descriptors(
     return apply_descriptors(values, symbols, functions)
 end
 
-# TODO: add documentation
-# Eduard 11 Apr 2022
 """
     apply_descriptors(values)
 
@@ -200,6 +188,28 @@ Dict{Union{Function, Symbol}, Number}(:max => 4, :mean => 2.5, :min => 1, :media
 function apply_descriptors(values::Array{<:Number})
     # default descriptors are chosen based on `values` dimension
     return apply_descriptors(values, 𝒟[ndims(values)])
+end
+
+"""
+    apply_descriptors(values, symbols, function)
+Evaluate `symbol` and `function` on `values`.\n
+Return a dictionary containing the associations symbol/function -> value
+## PARAMETERS
+    * `values` is a `Vector{<:Number}`.
+    * `symbols` is a `Symbols`.
+    * `functions` is a `Function`.
+## EXAMPLE
+```julia-repl
+julia> descriptions = apply_descriptors([1,2,3,4],[:min,:mean],[maximum])
+Dict{Union{Function, Symbol}, Number}(maximum => 4,:mean => 2.5, :min => 1)
+```
+"""
+function apply_descriptors(
+    values::Array{<:Number},
+    symbols::Array{Symbol},
+    fun::Function
+)
+    return apply_descriptors(values, symbols, [fun])
 end
 
 """
@@ -243,28 +253,6 @@ function apply_descriptors(
     fun::Function
 )
     return apply_descriptors(values, [symbol], [fun])
-end
-
-"""
-    apply_descriptors(values, symbol, function)
-Evaluate `symbol` and `function` on `values`.\n
-Return a dictionary containing the associations symbol/function -> value
-## PARAMETERS
-    * `values` is a `Vector{<:Number}`.
-    * `symbols` is a `Symbols`.
-    * `functions` is a `Function`.
-## EXAMPLE
-```julia-repl
-julia> descriptions = apply_descriptors([1,2,3,4],[:min,:mean],[maximum])
-Dict{Union{Function, Symbol}, Number}(maximum => 4,:mean => 2.5, :min => 1)
-```
-"""
-function apply_descriptors(
-    values::Array{<:Number},
-    symbol::Array{Symbol},
-    fun::Function
-)
-    return apply_descriptors(values, symbol, [fun])
 end
 
 end # module

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -1,5 +1,21 @@
 module SoleFunctions
 
-# Write your package code here.
+using Statistics
+using Catch22
+
+const desc_dict = Dict{Symbol,Function}(
+    :mean => mean,
+    :min => minimum,
+    :max => maximum,
+    :median => median,
+    :quantile_1 => (q_1 = x -> quantile(x, 0.25)),
+    :quantile_3 =>(q_3 = x -> quantile(x, 0.75)),
+    # allow catch22 desc
+    (getnames(catch22) .=> catch22)...
+)
+
+const auto_desc_by_dim = Dict{Integer,Vector{Symbol}}(
+    1 => [:mean, :min, :max, :quantile_1, :median, :quantile_3]
+)
 
 end

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -31,7 +31,7 @@ Return a dictionary containing the associations :symbol -> value (e.g :mean -> 3
 
 ## PARAMETERS
 * `descfun` is a `Vector` of Symbols which are mapped to specific functions.
-* `values` are a `Vector` of Numbers on which the description functions are applied.
+* `values` is a `Vector` of Numbers on which the description functions are applied.
 
 ## EXAMPLE
 ```julia-repl 

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -8,7 +8,7 @@ using Catch22
 export apply_descriptors
 
 # function dictionary
-const desc_dict = Dict{Symbol,Function}(
+const 𝒮 = Dict{Symbol,Function}(
     :mean => mean,
     :min => minimum,
     :max => maximum,
@@ -20,7 +20,7 @@ const desc_dict = Dict{Symbol,Function}(
 )
 
 # default functions by dimension
-const dim_desc = Dict{Integer,Vector{Symbol}}(
+const 𝒟 = Dict{Integer,Vector{Symbol}}(
     # TODO add default functions for other dimensions
     0 => [:mean, :min, :max],
     1 => [:mean, :min, :max, :quantile_1, :median, :quantile_3],
@@ -28,75 +28,58 @@ const dim_desc = Dict{Integer,Vector{Symbol}}(
 )
 
 """ 
-    apply_descriptors(descriptors, values)
+    apply_descriptors(values, descriptors, functions)
 
-Evaluate `descriptors` with `values`.\n
-Return a dictionary containing the associations descriptor -> value
+Evaluate `descriptors` and `functions` with `values`.\n
+Return a dictionary containing the associations descriptor/function -> value
 
 ## PARAMETERS
-* `descriptors` is a `Vector` containing both Symbols and Functions.
-* `values` is a `Vector` of Numbers on which the description functions are applied.
+* `values` is a `Vector{<:Number}`.
+* `descriptors` is a `Vector{Symbol}`.
+* `functions` is a `Vector{Function}`.
 
 ## EXAMPLE
 ```julia-repl 
-julia> desc_syms = [:mean, :min, maximum]
-julia> values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-julia> values_description = descriptors(desc_syms, values)
-Dict{Symbol, Real}(:max => 10, :mean => 5.5, :min => 1)\n
+julia> descriptions = apply_descriptors([1,2,3,4], [:min, :mean], [maximum])
+Dict{Union{Function, Symbol}, Number}(:mean => 2.5, maximum => 4, :min => 1)\n\n
+```
+
+    apply_descriptors(values, descriptors)
+
+## EXAMPLE
+```julia-repl 
+julia> descriptions = apply_descriptors([1,2,3,4], [:min, :mean])
+Dict{Union{Function, Symbol}, Number}(:mean => 2.5, :min => 1)\n\n
 ```
 
     apply_descriptors(values)
-Depending on `values` dimension, apply default functions.
+Evaluate default descriptors with values, based on values dimension
 
-# TODO - show to the user which functions are applied
-
-## PARAMETERS
-* `values` is a `Vector` of Numbers on which the description functions are applied.
-\n
+# TODO - Show 𝒟 content
 """
-function apply_descriptors(descriptors::Vector{Any},  values::Array{<:Number})
-    # descriptors must contain only Function and Symbol types
-    try
-        convert(Vector{Union{Function, Symbol}}, descriptors)
-    catch e
-        @error "Argument descriptors must contain only Function and Symbol types"
-    end
+function apply_descriptors(values::Array{<:Number}, symbols::Array{Symbol})
+    output = Dict{Union{Symbol, Function}, Number}()
+    d = ndims(values)
 
-    # returned dictionary
-    answer = Dict{Union{Symbol, Function}, Real}()
+    [@warn ":$s is not a valid symbol for dimension $d" for s in symbols if s ∉ 𝒟[d]]
+    [push!(output, s => 𝒮[s](values)) for s in symbols if s in 𝒟[d]]  
 
-    # all description functions are applied, results are stored in a new "answer" entry
-    for desc in descriptors
-        if isa(desc, Symbol)
-            push!(answer, desc => desc_dict[desc](values))
-        else
-            push!(answer, desc => desc(values))
-        end
-    end
-
-    return answer
+    return output
 end
 
-function apply_descriptors(descriptors::Vector{Symbol}, values::Array{<:Number})
-    answer = Dict{Symbol, Real}()
-    [push!(answer, desc => desc_dict[desc](values)) for desc in descriptors]
-    return answer
+function apply_descriptors(values::Array{<:Number}, symbols::Array{Symbol}, functions::Array{<:Function})
+    output = apply_descriptors(values, symbols)
+    [push!(output, f => f(values)) for f in functions]    
+    return output
 end
 
-function apply_descriptors(descriptor::Symbol, values::Array{<:Number})
-    return apply_descriptors([descriptor], values)
-end
-
-function apply_descriptors(values::Number)
-    return apply_descriptors(dim_desc[0], [values])
+function apply_descriptors(values::Array{<:Number}, functions::Array{<:Function}, symbols::Array{Symbol})
+    return apply_descriptors(values, symbols, functions)
 end
 
 function apply_descriptors(values::Array{<:Number})
-    dims = ndims(values)
-    return apply_descriptors(dim_desc[dims], values)
+    # default descriptors are chosen based on `values` dimension
+    return apply_descriptors(values, 𝒟[ndims(values)])
 end
 
 end # module
-
-#da scrivere nella pull request:
-#bisogna stare attenti ai tipi in apply descriptors

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -8,7 +8,6 @@ using Catch22
 export get_desc
 
 # taken from https://github.com/aclai-lab/SoleBase.jl/blob/dev/src/data/dataset/describe.jl
-
 const desc_dict = Dict{Symbol,Function}(
     :mean => mean,
     :min => minimum,

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -29,31 +29,31 @@ const 𝒟 = Dict{Integer,Vector{Symbol}}(
 )
 
 """
-    apply_descriptors(values, descriptors, functions)
+    apply_descriptors(values, symbols)
 
-Evaluate `descriptors` and `functions` with `values`.\n
-Return a dictionary containing the associations descriptor/function -> value
+Return a dictionary obtained by the evaluation of `symbols` corresponding functions
+on `values`
 
+the possible `symbols` are choosen from a dictionary defined as follows
+
+    :mean           =>  mean
+    :min            =>  minimum
+    :max            =>  maximum
+    :median         =>  median
+    :quantile_1     =>  quantile(x, 0.25)
+    :quantile_3     =>  quantile(x, 0.75)
+    ...
+
+catch22 functions are also implemented,
+see the documentation here: "https://github.com/chlubba/catch22/wiki/Feature-Descriptions"
 ## PARAMETERS
-* `values` is a `Vector{<:Number}`.
-* `descriptors` is a `Vector{Symbol}`.
-* `functions` is a `Vector{Function}`.
-## EXAMPLE
-```julia-repl
-julia> descriptions = apply_descriptors([1,2,3,4], [:min, :mean], [maximum])
-Dict{Union{Function, Symbol}, Number}(:mean => 2.5, maximum => 4, :min => 1)\n\n
-```
----
-    apply_descriptors(values, descriptors)
-
+    * `values` is a `Vector{<:Number}`.
+    * `symbols` is a `Vector{Symbol}`.
 ## EXAMPLE
 ```julia-repl
 julia> descriptions = apply_descriptors([1,2,3,4], [:min, :mean])
-Dict{Union{Function, Symbol}, Number}(:mean => 2.5, :min => 1)\n\n
+Dict{Union{Function, Symbol}, Number}(:mean => 2.5, :min => 1)\n
 ```
-
-    apply_descriptors(values)
-Evaluate default descriptors with values, based on values dimension.
 """
 function apply_descriptors(values::Array{<:Number}, symbols::Array{Symbol})
     output = Dict{Union{Symbol, Function}, Number}()
@@ -67,12 +67,38 @@ end
 
 # TODO: add documentation
 # Eduard 11 Apr 2022
+"""
+    apply_descriptors(values,symbol)
+
+evaluates `symbol` corresponding function on `values`
+## PARAMETERS
+* `values` is a `Vector{<:Number}`.
+* `symbols` is a `Symbol`.
+## EXAMPLE
+```julia-repl
+julia> descriptions = apply_descriptors([1,2,3,4], [:min])
+Dict{Union{Function, Symbol}, Number}(:min => 1)
+```
+"""
 function apply_descriptors(values::Array{<:Number}, symbol::Symbol)
     return apply_descriptors(values, [symbol])
 end
 
 # TODO: add documentation
 # Eduard 11 Apr 2022
+"""
+    apply_descriptors(values,functions)
+
+evaluates `functions` on `values`
+## PARAMETERS
+* `values` is a `Vector{<:Number}`.
+* `functions` is a `Array{<:Function}`.
+## EXAMPLE
+```julia-repl
+julia> descriptions = apply_descriptors([1,2,3,4], [minimum,maximum])
+Dict{Union{Function, Symbol}, Number}(minimum => 1,maximum => 4)
+```
+"""
 function apply_descriptors(values::Array{<:Number}, functions::Array{<:Function})
     output = Dict{Union{Symbol, Function}, Number}()
 
@@ -82,12 +108,39 @@ end
 
 # TODO: add documentation
 # Eduard 11 Apr 2022
+"""
+    apply_descriptors(values,function)
+
+evaluates `function` on `values`
+## PARAMETERS
+* `values` is a `Vector{<:Number}`.
+* `functions` is a `Function`.
+## EXAMPLE
+```julia-repl
+julia> descriptions = apply_descriptors([1,2,3,4], [maximum])
+Dict{Union{Function, Symbol}, Number}(maximum => 4)
+```
+"""
 function apply_descriptors(values::Array{<:Number}, f::Function)
     return apply_descriptors(values, [f])
 end
 
 # TODO: add documentation
 # Eduard 11 Apr 2022
+"""
+    apply_descriptors(values, symbols, functions)
+Evaluate `symbols` and `functions` on `values`.\n
+Return a dictionary containing the associations symbols/function -> value
+## PARAMETERS
+    * `values` is a `Vector{<:Number}`.
+    * `symbols` is a `Vector{Symbol}`.
+    * `functions` is a `Vector{Function}`.
+## EXAMPLE
+```julia-repl
+julia> descriptions = apply_descriptors([1,2,3,4],[maximum],[:min, :mean])
+Dict{Union{Function, Symbol}, Number}(maximum => 4,:mean => 2.5, :min => 1)
+```
+"""
 function apply_descriptors(
     values::Array{<:Number},
     symbols::Array{Symbol},
@@ -100,6 +153,20 @@ end
 
 # TODO: add documentation
 # Eduard 11 Apr 2022
+"""
+    apply_descriptors(values, functions, symbols)
+Evaluate `symbols` and `functions` on `values`.\n
+Return a dictionary containing the associations symbols/function -> value
+## PARAMETERS
+    * `values` is a `Vector{<:Number}`.
+    * `symbols` is a `Vector{Symbol}`.
+    * `functions` is a `Vector{Function}`.
+## EXAMPLE
+```julia-repl
+julia> descriptions = apply_descriptors([1,2,3,4], [:min, :mean], [maximum])
+Dict{Union{Function, Symbol}, Number}(maximum => 4, :mean => 2.5, :min => 1)
+```
+"""
 function apply_descriptors(
     values::Array{<:Number},
     functions::Array{<:Function},
@@ -110,9 +177,94 @@ end
 
 # TODO: add documentation
 # Eduard 11 Apr 2022
+"""
+    apply_descriptors(values)
+
+Return a dictionary containing the evaluation of default functions on `values`
+
+default functions are choosen according to the dimensions of the data as
+follows:
+
+    1 => [:max, :mean, :min, :median, :quantile_1, :quantile_3, getnames(catch22)...]
+    2 => [:max, :mean, :median, :min]
+    ...
+## PARAMETERS
+    * `values` is a `Vector{<:Number}`.
+## EXAMPLE
+```julia-repl
+julia> descriptions = apply_descriptors([1,2,3,4])
+Dict{Union{Function, Symbol}, Number}(:max => 4, :mean => 2.5, :min => 1, :median => 2.5,
+:quantile_1 => 1.75, :quantile_3 => 3.25, ...)\n
+```
+"""
 function apply_descriptors(values::Array{<:Number})
     # default descriptors are chosen based on `values` dimension
     return apply_descriptors(values, 𝒟[ndims(values)])
+end
+
+"""
+    apply_descriptors(values, symbol, functions)
+Evaluate `symbol` and `functions` on `values`.\n
+Return a dictionary containing the associations symbol/function -> value
+## PARAMETERS
+    * `values` is a `Vector{<:Number}`.
+    * `symbols` is a `Symbol`.
+    * `functions` is a `Vector{<:Function}`.
+## EXAMPLE
+```julia-repl
+julia> descriptions = apply_descriptors([1,2,3,4],[maximum],[:min])
+Dict{Union{Function, Symbol}, Number}(maximum => 4, :min => 1)
+```
+"""
+function apply_descriptors(
+    values::Array{<:Number},
+    symbol::Symbol,
+    functions::Array{<:Function}
+)
+    return apply_descriptors(values, [symbol], functions)
+end
+"""
+    apply_descriptors(values, symbol, function)
+Evaluate `symbol` and `function` on `values`.\n
+Return a dictionary containing the associations symbol/function -> value
+## PARAMETERS
+    * `values` is a `Vector{<:Number}`.
+    * `symbols` is a `Symbol`.
+    * `functions` is a `Function`.
+## EXAMPLE
+```julia-repl
+julia> descriptions = apply_descriptors([1,2,3,4],[:min],[maximum])
+Dict{Union{Function, Symbol}, Number}(maximum => 4, :min => 1)
+```
+"""
+function apply_descriptors(
+    values::Array{<:Number},
+    symbol::Symbol,
+    fun::Function
+)
+    return apply_descriptors(values, [symbol], [fun])
+end
+
+"""
+    apply_descriptors(values, symbol, function)
+Evaluate `symbol` and `function` on `values`.\n
+Return a dictionary containing the associations symbol/function -> value
+## PARAMETERS
+    * `values` is a `Vector{<:Number}`.
+    * `symbols` is a `Symbols`.
+    * `functions` is a `Function`.
+## EXAMPLE
+```julia-repl
+julia> descriptions = apply_descriptors([1,2,3,4],[:min,:mean],[maximum])
+Dict{Union{Function, Symbol}, Number}(maximum => 4,:mean => 2.5, :min => 1)
+```
+"""
+function apply_descriptors(
+    values::Array{<:Number},
+    symbol::Array{Symbol},
+    fun::Function
+)
+    return apply_descriptors(values, symbol, [fun])
 end
 
 end # module

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -3,6 +3,7 @@ module SoleFunctions
 using Statistics
 using Catch22
 
+
 const desc_dict = Dict{Symbol,Function}(
     :mean => mean,
     :min => minimum,
@@ -17,5 +18,6 @@ const desc_dict = Dict{Symbol,Function}(
 const auto_desc_by_dim = Dict{Integer,Vector{Symbol}}(
     1 => [:mean, :min, :max, :quantile_1, :median, :quantile_3]
 )
+
 
 end

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -21,10 +21,10 @@ const 𝒮 = Dict{Symbol,Function}(
 
 # default functions by dimension
 const 𝒟 = Dict{Integer,Vector{Symbol}}(
-    # TODO add default functions for other dimensions
+    # TODO add default functions for other dimensions 
     0 => [:mean, :min, :max],
     1 => [:mean, :min, :max, :quantile_1, :median, :quantile_3],
-    2 => [:mean, :min, :max, :median]
+    2 => [:mean, :min, :max, :median] 
 )
 
 """ 

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -21,13 +21,17 @@ const 𝒮 = Dict{Symbol,Function}(
 
 # default functions by dimension
 const 𝒟 = Dict{Integer,Vector{Symbol}}(
-    # TODO add default functions for other dimensions 
+    # TODO manage 0, 2 and higher dimensions.
     0 => [:mean, :min, :max],
     1 => [:mean, :min, :max, :quantile_1, :median, :quantile_3],
-    2 => [:mean, :min, :max, :median] 
+    2 => [:mean, :min, :max, :median]
 )
 
-""" 
+@show 𝒟[1]
+
+print( DN_HistogramMode_10([1 2 3 4; 5 6 7 8] ))
+
+"""
     apply_descriptors(values, descriptors, functions)
 
 Evaluate `descriptors` and `functions` with `values`.\n
@@ -38,7 +42,7 @@ Return a dictionary containing the associations descriptor/function -> value
 * `descriptors` is a `Vector{Symbol}`.
 * `functions` is a `Vector{Function}`.
 ## EXAMPLE
-```julia-repl 
+```julia-repl
 julia> descriptions = apply_descriptors([1,2,3,4], [:min, :mean], [maximum])
 Dict{Union{Function, Symbol}, Number}(:mean => 2.5, maximum => 4, :min => 1)\n\n
 ```
@@ -46,7 +50,7 @@ Dict{Union{Function, Symbol}, Number}(:mean => 2.5, maximum => 4, :min => 1)\n\n
     apply_descriptors(values, descriptors)
 
 ## EXAMPLE
-```julia-repl 
+```julia-repl
 julia> descriptions = apply_descriptors([1,2,3,4], [:min, :mean])
 Dict{Union{Function, Symbol}, Number}(:mean => 2.5, :min => 1)\n\n
 ```
@@ -61,18 +65,26 @@ function apply_descriptors(values::Array{<:Number}, symbols::Array{Symbol})
     d = ndims(values)
 
     [@warn ":$s is not a valid symbol for dimension $d" for s in symbols if s ∉ 𝒟[d]]
-    [push!(output, s => 𝒮[s](values)) for s in symbols if s in 𝒟[d]]  
+    [push!(output, s => 𝒮[s](values)) for s in symbols if s in 𝒟[d]]
 
     return output
 end
 
-function apply_descriptors(values::Array{<:Number}, symbols::Array{Symbol}, functions::Array{<:Function})
+function apply_descriptors(
+    values::Array{<:Number},
+    symbols::Array{Symbol},
+    functions::Array{<:Function}
+)
     output = apply_descriptors(values, symbols)
-    [push!(output, f => f(values)) for f in functions]    
+    [push!(output, f => f(values)) for f in functions]
     return output
 end
 
-function apply_descriptors(values::Array{<:Number}, functions::Array{<:Function}, symbols::Array{Symbol})
+function apply_descriptors(
+    values::Array{<:Number},
+    functions::Array{<:Function},
+    symbols::Array{Symbol}
+)
     return apply_descriptors(values, symbols, functions)
 end
 

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -12,49 +12,55 @@ export apply_descriptors
 
 # function dictionary
 const 𝒮 = Dict{Symbol,Function}(
-    :mean => mean,
-    :min => minimum,
-    :max => maximum,
-    :median => median,
-    :quantile_1 => (q_1 = x -> quantile(x, 0.25)),
-    :quantile_3 =>(q_3 = x -> quantile(x, 0.75)),
+    :mean       => mean,
+    :minimum    => minimum,
+    :maximum    => maximum,
+    :median     => median,
+    :quantile_1 => (x -> quantile(x, 0.25)),
+    :quantile_3 => (x -> quantile(x, 0.75)),
     # catch22 descriptors
     (getnames(catch22) .=> catch22)...
 )
 
 # default functions by dimension
 const 𝒟 = Dict{Integer,Vector{Symbol}}(
-    1 => [:max, :mean, :min, :median, :quantile_1, :quantile_3, getnames(catch22)...],
-    2 => [:max, :mean, :median, :min]
+    1 => [:maximum, :mean, :minimum, :median, :quantile_1, :quantile_3, getnames(catch22)...],
+    2 => [:maximum, :mean, :median, :minimum]
 )
 
 """
     apply_descriptors(values, symbols)
 
 Return a dictionary obtained by the evaluation of `symbols` corresponding functions
-on `values`
+on `values`.
 
-the possible `symbols` are choosen from a dictionary defined as follows
+Tthe possible `symbols` are choosen from a dictionary defined as follows:
 
     :mean           =>  mean
-    :min            =>  minimum
-    :max            =>  maximum
+    :minimum        =>  minimum
+    :maximum        =>  maximum
     :median         =>  median
     :quantile_1     =>  quantile(x, 0.25)
     :quantile_3     =>  quantile(x, 0.75)
     ...
 
-catch22 functions are also implemented,
-see the documentation here: "https://github.com/chlubba/catch22/wiki/Feature-Descriptions"
+Catch22 functions are also implemented, see the documentation here:
+"https://github.com/chlubba/catch22/wiki/Feature-Descriptions"
+
 ## PARAMETERS
-    * `values` is a `Vector{<:Number}`.
-    * `symbols` is a `Vector{Symbol}`.
+- `values` is a `Vector{<:Number}`.
+- `symbols` is a `Vector{Symbol}`.
+
 ## EXAMPLE
 ```julia-repl
-julia> descriptions = apply_descriptors([1,2,3,4], [:min, :mean])
-Dict{Union{Function, Symbol}, Number}(:mean => 2.5, :min => 1)\n
+julia> descriptions = apply_descriptors([1,2,3,4], [:minimum, :mean])
+Dict{Union{Function, Symbol}, Number}(:mean => 2.5, :minimum => 1)\n
 ```
 """
+# TODO: A single documentation for all these functions
+# Eduard 12 Apr 2022
+function apply_descriptors end
+
 function apply_descriptors(values::Array{<:Number}, symbols::Array{Symbol})
     output = Dict{Union{Symbol, Function}, Number}()
     d = ndims(values)
@@ -69,13 +75,15 @@ end
     apply_descriptors(values,symbol)
 
 evaluates `symbol` corresponding function on `values`
+
 ## PARAMETERS
-* `values` is a `Vector{<:Number}`.
-* `symbols` is a `Symbol`.
+- `values` is a `Vector{<:Number}`.
+- `symbols` is a `Symbol`.
+
 ## EXAMPLE
 ```julia-repl
-julia> descriptions = apply_descriptors([1,2,3,4], [:min])
-Dict{Union{Function, Symbol}, Number}(:min => 1)
+julia> descriptions = apply_descriptors([1,2,3,4], [:minimum])
+Dict{Union{Function, Symbol}, Number}(:minimum => 1)
 ```
 """
 function apply_descriptors(values::Array{<:Number}, symbol::Symbol)
@@ -86,9 +94,11 @@ end
     apply_descriptors(values,functions)
 
 evaluates `functions` on `values`
+
 ## PARAMETERS
-* `values` is a `Vector{<:Number}`.
-* `functions` is a `Array{<:Function}`.
+- `values` is a `Vector{<:Number}`.
+- `functions` is a `Array{<:Function}`.
+
 ## EXAMPLE
 ```julia-repl
 julia> descriptions = apply_descriptors([1,2,3,4], [minimum,maximum])
@@ -106,9 +116,11 @@ end
     apply_descriptors(values,function)
 
 evaluates `function` on `values`
+
 ## PARAMETERS
-* `values` is a `Vector{<:Number}`.
-* `functions` is a `Function`.
+- `values` is a `Vector{<:Number}`.
+- `functions` is a `Function`.
+
 ## EXAMPLE
 ```julia-repl
 julia> descriptions = apply_descriptors([1,2,3,4], [maximum])
@@ -121,16 +133,19 @@ end
 
 """
     apply_descriptors(values, symbols, functions)
+
 Evaluate `symbols` and `functions` on `values`.\n
 Return a dictionary containing the associations symbols/function -> value
+
 ## PARAMETERS
-    * `values` is a `Vector{<:Number}`.
-    * `symbols` is a `Vector{Symbol}`.
-    * `functions` is a `Vector{Function}`.
+- `values` is a `Vector{<:Number}`
+- `symbols` is a `Vector{Symbol}`.
+- `functions` is a `Vector{Function}`.
+
 ## EXAMPLE
 ```julia-repl
-julia> descriptions = apply_descriptors([1,2,3,4],[maximum],[:min, :mean])
-Dict{Union{Function, Symbol}, Number}(maximum => 4,:mean => 2.5, :min => 1)
+julia> descriptions = apply_descriptors([1,2,3,4],[maximum],[:minimum, :mean])
+Dict{Union{Function, Symbol}, Number}(maximum => 4,:mean => 2.5, :minimum => 1)
 ```
 """
 function apply_descriptors(
@@ -147,14 +162,16 @@ end
     apply_descriptors(values, functions, symbols)
 Evaluate `symbols` and `functions` on `values`.\n
 Return a dictionary containing the associations symbols/function -> value
+
 ## PARAMETERS
-    * `values` is a `Vector{<:Number}`.
-    * `symbols` is a `Vector{Symbol}`.
-    * `functions` is a `Vector{Function}`.
+- `values` is a `Vector{<:Number}`.
+- `symbols` is a `Vector{Symbol}`.
+- `functions` is a `Vector{Function}`.
+
 ## EXAMPLE
 ```julia-repl
-julia> descriptions = apply_descriptors([1,2,3,4], [:min, :mean], [maximum])
-Dict{Union{Function, Symbol}, Number}(maximum => 4, :mean => 2.5, :min => 1)
+julia> descriptions = apply_descriptors([1,2,3,4], [:minimum, :mean], [maximum])
+Dict{Union{Function, Symbol}, Number}(maximum => 4, :mean => 2.5, :minimum => 1)
 ```
 """
 function apply_descriptors(
@@ -173,16 +190,17 @@ Return a dictionary containing the evaluation of default functions on `values`
 default functions are choosen according to the dimensions of the data as
 follows:
 
-    1 => [:max, :mean, :min, :median, :quantile_1, :quantile_3, getnames(catch22)...]
-    2 => [:max, :mean, :median, :min]
+    1 => [:maximum, :mean, :minimum, :median, :quantile_1, :quantile_3, getnames(catch22)...]
+    2 => [:maximum, :mean, :median, :minimum]
     ...
 ## PARAMETERS
-    * `values` is a `Vector{<:Number}`.
+- `values` is a `Vector{<:Number}`.
+
 ## EXAMPLE
 ```julia-repl
 julia> descriptions = apply_descriptors([1,2,3,4])
-Dict{Union{Function, Symbol}, Number}(:max => 4, :mean => 2.5, :min => 1, :median => 2.5,
-:quantile_1 => 1.75, :quantile_3 => 3.25, ...)\n
+Dict{Union{Function, Symbol}, Number}(:maximum => 4, :mean => 2.5, :minimum => 1,
+:median => 2.5, :quantile_1 => 1.75, :quantile_3 => 3.25, ...)\n
 ```
 """
 function apply_descriptors(values::Array{<:Number})
@@ -192,16 +210,19 @@ end
 
 """
     apply_descriptors(values, symbols, function)
+
 Evaluate `symbol` and `function` on `values`.\n
 Return a dictionary containing the associations symbol/function -> value
+
 ## PARAMETERS
     * `values` is a `Vector{<:Number}`.
     * `symbols` is a `Symbols`.
-    * `functions` is a `Function`.
+    * `functions` is a `Function`. #TODO
+
 ## EXAMPLE
 ```julia-repl
-julia> descriptions = apply_descriptors([1,2,3,4],[:min,:mean],[maximum])
-Dict{Union{Function, Symbol}, Number}(maximum => 4,:mean => 2.5, :min => 1)
+julia> descriptions = apply_descriptors([1,2,3,4],[:minimum,:mean],[maximum])
+Dict{Union{Function, Symbol}, Number}(maximum => 4,:mean => 2.5, :minimum => 1)
 ```
 """
 function apply_descriptors(
@@ -214,16 +235,19 @@ end
 
 """
     apply_descriptors(values, symbol, functions)
+
 Evaluate `symbol` and `functions` on `values`.\n
 Return a dictionary containing the associations symbol/function -> value
+
 ## PARAMETERS
-    * `values` is a `Vector{<:Number}`.
-    * `symbols` is a `Symbol`.
-    * `functions` is a `Vector{<:Function}`.
+- `values` is a `Vector{<:Number}`.
+- `symbols` is a `Symbol`.
+- `functions` is a `Vector{<:Function}`.
+
 ## EXAMPLE
 ```julia-repl
-julia> descriptions = apply_descriptors([1,2,3,4],[maximum],[:min])
-Dict{Union{Function, Symbol}, Number}(maximum => 4, :min => 1)
+julia> descriptions = apply_descriptors([1,2,3,4],[maximum],[:minimum])
+Dict{Union{Function, Symbol}, Number}(maximum => 4, :minimum => 1)
 ```
 """
 function apply_descriptors(
@@ -233,18 +257,22 @@ function apply_descriptors(
 )
     return apply_descriptors(values, [symbol], functions)
 end
+
 """
     apply_descriptors(values, symbol, function)
+
 Evaluate `symbol` and `function` on `values`.\n
 Return a dictionary containing the associations symbol/function -> value
+
 ## PARAMETERS
-    * `values` is a `Vector{<:Number}`.
-    * `symbols` is a `Symbol`.
-    * `functions` is a `Function`.
+- `values` is a `Vector{<:Number}`.
+- `symbols` is a `Symbol`.
+- `functions` is a `Function`.
+
 ## EXAMPLE
 ```julia-repl
-julia> descriptions = apply_descriptors([1,2,3,4],[:min],[maximum])
-Dict{Union{Function, Symbol}, Number}(maximum => 4, :min => 1)
+julia> descriptions = apply_descriptors([1,2,3,4],[:minimum],[maximum])
+Dict{Union{Function, Symbol}, Number}(maximum => 4, :minimum => 1)
 ```
 """
 function apply_descriptors(

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -23,7 +23,7 @@ const desc_dict = Dict{Symbol,Function}(
 const dim_desc = Dict{Integer,Vector{Symbol}}(
     # TODO add default functions for other dimensions
     0 => [:mean, :min, :max],
-    1 => [:min, :max, :quantile_1, :median, :quantile_3],
+    1 => [:mean,:min, :max, :quantile_1, :median, :quantile_3],
     2 => [:mean, :min, :max, :quantile_1, :median, :quantile_3]
 )
 

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -8,7 +8,7 @@ using Catch22
 export apply_descriptors
 
 # function dictionary
-const desc_dict = Dict{Symbol,Function}(
+const 𝒮 = Dict{Symbol,Function}(
     :mean => mean,
     :min => minimum,
     :max => maximum,
@@ -20,79 +20,59 @@ const desc_dict = Dict{Symbol,Function}(
 )
 
 # default functions by dimension
-const dim_desc = Dict{Integer,Vector{Symbol}}(
+const 𝒟 = Dict{Integer,Vector{Symbol}}(
     # TODO add default functions for other dimensions
     0 => [:mean, :min, :max],
-    1 => [:mean,:min, :max, :quantile_1, :median, :quantile_3],
-    2 => [:mean, :min, :max, :quantile_1, :median, :quantile_3]
+    1 => [:mean, :min, :max, :quantile_1, :median, :quantile_3],
+    2 => [:mean, :min, :max, :median]
 )
 
 """ 
-    apply_descriptors(descriptors, values)
-
-Evaluate `descriptors` with `values`.\n
-Return a dictionary containing the associations descriptor -> value
-
+    apply_descriptors(values, descriptors, functions)
+Evaluate `descriptors` and `functions` with `values`.\n
+Return a dictionary containing the associations descriptor/function -> value
 ## PARAMETERS
-* `descriptors` is a `Vector` containing both Symbols and Functions.
-* `values` is a `Vector` of Numbers on which the description functions are applied.
-
+* `values` is a `Vector{<:Number}`.
+* `descriptors` is a `Vector{Symbol}`.
+* `functions` is a `Vector{Function}`.
 ## EXAMPLE
 ```julia-repl 
-julia> desc_syms = [:mean, :min, maximum]
-julia> values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-julia> values_description = descriptors(desc_syms, values)
-Dict{Symbol, Real}(:max => 10, :mean => 5.5, :min => 1)\n
+julia> descriptions = apply_descriptors([1,2,3,4], [:min, :mean], [maximum])
+Dict{Union{Function, Symbol}, Number}(:mean => 2.5, maximum => 4, :min => 1)\n\n
 ```
-
+    apply_descriptors(values, descriptors)
+## EXAMPLE
+```julia-repl 
+julia> descriptions = apply_descriptors([1,2,3,4], [:min, :mean])
+Dict{Union{Function, Symbol}, Number}(:mean => 2.5, :min => 1)\n\n
+```
     apply_descriptors(values)
-Depending on `values` dimension, apply default functions.
-
-# TODO - show to the user which functions are applied
-
-## PARAMETERS
-* `values` is a `Vector` of Numbers on which the description functions are applied.
-\n
+Evaluate default descriptors with values, based on values dimension
+# TODO - Show 𝒟 content
 """
-function apply_descriptors(descriptors::Vector{Any},  values::Array{<:Number})
-    # descriptors must contain only Function and Symbol types
-    try
-        convert(Vector{Union{Function, Symbol}}, descriptors)
-    catch e
-        @error "Argument descriptors must contain only Function and Symbol types"
-    end
+function apply_descriptors(values::Array{<:Number}, symbols::Array{Symbol})
+    output = Dict{Union{Symbol, Function}, Number}()
+    d = ndims(values)
 
-    # returned dictionary
-    answer = Dict{Union{Symbol, Function}, Real}()
+    [@warn ":$s is not a valid symbol for dimension $d" for s in symbols if s ∉ 𝒟[d]]
+    [push!(output, s => 𝒮[s](values)) for s in symbols if s in 𝒟[d]]  
 
-    # all description functions are applied, results are stored in a new "answer" entry
-    for desc in descriptors
-        if isa(desc, Symbol)
-            push!(answer, desc => desc_dict[desc](values))
-        else
-            push!(answer, desc => desc(values))
-        end
-    end
-
-    return answer
+    return output
 end
 
-function apply_descriptors(descriptors::Vector{Symbol}, values::Array{<:Number})
-    answer = Dict{Symbol, Real}()
-    [push!(answer, desc => desc_dict[desc](values)) for desc in descriptors]
-    return answer
+function apply_descriptors(values::Array{<:Number}, symbols::Array{Symbol}, functions::Array{<:Function})
+    output = apply_descriptors(values, symbols)
+    [push!(output, f => f(values)) for f in functions]    
+    return output
 end
 
-function apply_descriptors(descriptor::Symbol, values::Array{<:Number})
-    return apply_descriptors( [descriptor] , values)
+function apply_descriptors(values::Array{<:Number}, functions::Array{<:Function}, symbols::Array{Symbol})
+    return apply_descriptors(values, symbols, functions)
 end
 
 function apply_descriptors(values::Array{<:Number})
-    dims = ndims(values)
-    return apply_descriptors( dim_desc[dims] , values)
+    # default descriptors are chosen based on `values` dimension
+    return apply_descriptors(values, 𝒟[ndims(values)])
 end
 
 end # module
-
-#da scrivere nella pull request:
-#bisogna stare attenti ai tipi in apply descriptors

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -1,5 +1,8 @@
 module SoleFunctions
 
+# TODO: add tests for the newly defined (dispatched) functions
+# Eduard 11 Apr 2022
+
 using Statistics
 using Catch22
 
@@ -40,7 +43,7 @@ Return a dictionary containing the associations descriptor/function -> value
 julia> descriptions = apply_descriptors([1,2,3,4], [:min, :mean], [maximum])
 Dict{Union{Function, Symbol}, Number}(:mean => 2.5, maximum => 4, :min => 1)\n\n
 ```
-
+---
     apply_descriptors(values, descriptors)
 
 ## EXAMPLE
@@ -62,6 +65,29 @@ function apply_descriptors(values::Array{<:Number}, symbols::Array{Symbol})
     return output
 end
 
+# TODO: add documentation
+# Eduard 11 Apr 2022
+function apply_descriptors(values::Array{<:Number}, symbol::Symbol)
+    return apply_descriptors(values, [symbol])
+end
+
+# TODO: add documentation
+# Eduard 11 Apr 2022
+function apply_descriptors(values::Array{<:Number}, functions::Array{<:Function})
+    output = Dict{Union{Symbol, Function}, Number}()
+
+    [push!(output, f => f(values)) for f in functions]
+    return output
+end
+
+# TODO: add documentation
+# Eduard 11 Apr 2022
+function apply_descriptors(values::Array{<:Number}, f::Function)
+    return apply_descriptors(values, [f])
+end
+
+# TODO: add documentation
+# Eduard 11 Apr 2022
 function apply_descriptors(
     values::Array{<:Number},
     symbols::Array{Symbol},
@@ -72,6 +98,8 @@ function apply_descriptors(
     return output
 end
 
+# TODO: add documentation
+# Eduard 11 Apr 2022
 function apply_descriptors(
     values::Array{<:Number},
     functions::Array{<:Function},
@@ -80,6 +108,8 @@ function apply_descriptors(
     return apply_descriptors(values, symbols, functions)
 end
 
+# TODO: add documentation
+# Eduard 11 Apr 2022
 function apply_descriptors(values::Array{<:Number})
     # default descriptors are chosen based on `values` dimension
     return apply_descriptors(values, 𝒟[ndims(values)])

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -5,9 +5,9 @@ using Catch22
 
 # -------------------------------------------------------------
 # exports
-export get_desc
+export apply_descriptors
 
-# taken from https://github.com/aclai-lab/SoleBase.jl/blob/dev/src/data/dataset/describe.jl
+# function dictionary
 const desc_dict = Dict{Symbol,Function}(
     :mean => mean,
     :min => minimum,
@@ -19,39 +19,80 @@ const desc_dict = Dict{Symbol,Function}(
     (getnames(catch22) .=> catch22)...
 )
 
-const auto_desc_by_dim = Dict{Integer,Vector{Symbol}}(
-    1 => [:mean, :min, :max, :quantile_1, :median, :quantile_3]
+# default functions by dimension
+const dim_desc = Dict{Integer,Vector{Symbol}}(
+    # TODO add default functions for other dimensions
+    0 => [:mean, :min, :max],
+    1 => [:min, :max, :quantile_1, :median, :quantile_3],
+    2 => [:mean, :min, :max, :quantile_1, :median, :quantile_3]
 )
 
 """ 
-    get_desc(descfun, values)
+    apply_descriptors(descriptors, values)
 
-Evaluate `descfun` with `values`.\n
-Return a dictionary containing the associations :symbol -> value (e.g :mean -> 3.5)
+Evaluate `descriptors` with `values`.\n
+Return a dictionary containing the associations descriptor -> value
 
 ## PARAMETERS
-* `descfun` is a `Vector` of Symbols which are mapped to specific functions.
+* `descriptors` is a `Vector` containing both Symbols and Functions.
 * `values` is a `Vector` of Numbers on which the description functions are applied.
 
 ## EXAMPLE
 ```julia-repl 
-julia> desc_syms = [:mean, :min, :max]
+julia> desc_syms = [:mean, :min, maximum]
 julia> values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-julia> values_description = get_desc(desc_syms, values)
-Dict{Symbol, Real}(:max => 10, :mean => 5.5, :min => 1)
+julia> values_description = descriptors(desc_syms, values)
+Dict{Symbol, Real}(:max => 10, :mean => 5.5, :min => 1)\n
 ```
+
+    apply_descriptors(values)
+Depending on `values` dimension, apply default functions.
+
+# TODO - show to the user which functions are applied
+
+## PARAMETERS
+* `values` is a `Vector` of Numbers on which the description functions are applied.
+\n
 """
-function get_desc(descfun::Vector{Symbol}, values::Vector{<:Number})
-    # a symbol is valid only if it is defined in desc_dict
-    for df in descfun
-        @assert df in keys(desc_dict) "`$(df)` is not a valid descriptor"
+function apply_descriptors(descriptors::Vector{Any},  values::Array{<:Number})
+    # descriptors must contain only Function and Symbol types
+    try
+        convert(Vector{Union{Function, Symbol}}, descriptors)
+    catch e
+        @error "Argument descriptors must contain only Function and Symbol types"
     end
 
-    ans_dict = Dict{Symbol, Real}()
-    apply(f, x) = f(x)
-    [push!(ans_dict, df => apply(desc_dict[df], values)) for df in descfun]
+    # returned dictionary
+    answer = Dict{Union{Symbol, Function}, Real}()
 
-    return ans_dict
+    # all description functions are applied, results are stored in a new "answer" entry
+    for desc in descriptors
+        if isa(desc, Symbol)
+            push!(answer, desc => desc_dict[desc](values))
+        else
+            push!(answer, desc => desc(values))
+        end
+    end
+
+    return answer
+end
+
+function apply_descriptors(descriptors::Vector{Symbol}, values::Array{<:Number})
+    answer = Dict{Symbol, Real}()
+    [push!(answer, desc => desc_dict[desc](values)) for desc in descriptors]
+    return answer
+end
+
+function apply_descriptors(descriptor::Symbol, values::Array{<:Number})
+    return apply_descriptors( [descriptor] , values)
+end
+
+function apply_descriptors(values::Array{<:Number})
+    dims = ndims(values)
+    return apply_descriptors( dim_desc[dims] , values)
 end
 
 end # module
+
+#da scrivere nella pull request:
+#bisogna stare attenti ai tipi in apply descriptors

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -26,7 +26,7 @@ const auto_desc_by_dim = Dict{Integer,Vector{Symbol}}(
 """ 
     get_desc(descfun, values)
 
-Apply functions represented by `descfun` to `values`.\n
+Evaluate `descfun` with `values`.\n
 Return a dictionary containing the associations :symbol -> value (e.g :mean -> 3.5)
 
 ## PARAMETERS

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -23,8 +23,8 @@ const desc_dict = Dict{Symbol,Function}(
 const dim_desc = Dict{Integer,Vector{Symbol}}(
     # TODO add default functions for other dimensions
     0 => [:mean, :min, :max],
-    1 => [:mean,:min, :max, :quantile_1, :median, :quantile_3],
-    2 => [:mean, :min, :max, :quantile_1, :median, :quantile_3]
+    1 => [:mean, :min, :max, :quantile_1, :median, :quantile_3],
+    2 => [:mean, :min, :max, :median]
 )
 
 """ 
@@ -84,12 +84,16 @@ function apply_descriptors(descriptors::Vector{Symbol}, values::Array{<:Number})
 end
 
 function apply_descriptors(descriptor::Symbol, values::Array{<:Number})
-    return apply_descriptors( [descriptor] , values)
+    return apply_descriptors([descriptor], values)
+end
+
+function apply_descriptors(values::Number)
+    return apply_descriptors(dim_desc[0], [values])
 end
 
 function apply_descriptors(values::Array{<:Number})
     dims = ndims(values)
-    return apply_descriptors( dim_desc[dims] , values)
+    return apply_descriptors(dim_desc[dims], values)
 end
 
 end # module

--- a/src/SoleFunctions.jl
+++ b/src/SoleFunctions.jl
@@ -22,14 +22,10 @@ const 𝒮 = Dict{Symbol,Function}(
 # default functions by dimension
 const 𝒟 = Dict{Integer,Vector{Symbol}}(
     # TODO manage 0, 2 and higher dimensions.
-    0 => [:mean, :min, :max],
-    1 => [:mean, :min, :max, :quantile_1, :median, :quantile_3],
-    2 => [:mean, :min, :max, :median]
+    0 => [:max, :mean, :min],
+    1 => [:max, :mean, :min, :median, :quantile_1, :quantile_3, getnames(catch22)...],
+    2 => [:max, :mean, :median, :min]
 )
-
-@show 𝒟[1]
-
-print( DN_HistogramMode_10([1 2 3 4; 5 6 7 8] ))
 
 """
     apply_descriptors(values, descriptors, functions)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,9 @@ rng = MersenneTwister(123)
     using Statistics
     using Catch22
 
+    # input in one-dimensional case
     one_dim = rand(Float64,100)
+    # symbol and function arrays used in the test
     sym_one = [:max,:mean]
     func_one = [minimum]
 
@@ -17,29 +19,7 @@ rng = MersenneTwister(123)
     sym_two = [:max]
     func_two = [minimum,mean]
 
-    @testset "values, symbols, functions test" begin
-
-        ans_t1d1 = Dict{Union{Symbol,Function},Number}(
-            :max => maximum(one_dim),
-            :mean => mean(one_dim),
-            minimum => minimum(one_dim)
-        )
-
-        @test_throws UndefVarError apply_descriptors(one_dim,sym_one,[nonexistent_function])
-        @test apply_descriptors(one_dim,sym_one,func_one) == ans_t1d1
-        @test apply_descriptors(one_dim,func_one,sym_one) == ans_t1d1
-
-        ans_t1d2 = Dict{Union{Symbol,Function},Number}(
-            :max => maximum(two_dim),
-            minimum => minimum(two_dim),
-            mean => mean(two_dim)
-        )
-
-        @test apply_descriptors(two_dim,sym_two,func_two) == ans_t1d2
-        @test apply_descriptors(two_dim,func_two,sym_two) == ans_t1d2
-
-    end
-
+    # all functions are tested for a certain dimension
     @testset "values only test" begin
 
         ans_t2d1 = Dict{Union{Symbol,Function},Number}(
@@ -61,6 +41,29 @@ rng = MersenneTwister(123)
 
         @test apply_descriptors(one_dim) == ans_t2d1
         @test apply_descriptors(two_dim) == ans_t2d2
+
+    end
+
+    @testset "values, symbols, functions test" begin
+
+        ans_t1d1 = Dict{Union{Symbol,Function},Number}(
+            :max => maximum(one_dim),
+            :mean => mean(one_dim),
+            minimum => minimum(one_dim)
+        )
+
+        @test_throws UndefVarError apply_descriptors(one_dim,sym_one,[nonexistent_function])
+        @test apply_descriptors(one_dim,sym_one,func_one) == ans_t1d1
+        @test apply_descriptors(one_dim,func_one,sym_one) == ans_t1d1
+
+        ans_t1d2 = Dict{Union{Symbol,Function},Number}(
+            :max => maximum(two_dim),
+            minimum => minimum(two_dim),
+            mean => mean(two_dim)
+        )
+
+        @test apply_descriptors(two_dim,sym_two,func_two) == ans_t1d2
+        @test apply_descriptors(two_dim,func_two,sym_two) == ans_t1d2
 
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,36 +18,44 @@ rng = MersenneTwister(123)
 
     @testset "values symbol & function test" begin
 
-        ans_t1d1 = Dict{Union{Symbol,Function},Number}(:max => maximum(one_dim), 
-                                                        :mean => mean(one_dim), 
-                                                        minimum => minimum(one_dim))
+        ans_t1d1 = Dict{Union{Symbol,Function},Number}(
+            :max => maximum(one_dim),
+            :mean => mean(one_dim),
+            minimum => minimum(one_dim)
+        )
 
         @test_throws UndefVarError apply_descriptors(one_dim,sym_one,[uselessFunc])
         @test apply_descriptors(one_dim,sym_one,func_one) == ans_t1d1
         @test apply_descriptors(one_dim,func_one,sym_one) == ans_t1d1
 
-        ans_t1d2 = Dict{Union{Symbol,Function},Number}(:max => maximum(two_dim), 
-                                                    minimum => minimum(two_dim),
-                                                    mean => mean(two_dim))
+        ans_t1d2 = Dict{Union{Symbol,Function},Number}(
+            :max => maximum(two_dim),
+            minimum => minimum(two_dim),
+            mean => mean(two_dim)
+        )
 
         @test apply_descriptors(two_dim,sym_two,func_two) == ans_t1d2
         @test apply_descriptors(two_dim,func_two,sym_two) == ans_t1d2
-        
+
     end
 
     @testset "values only test" begin
-        
-        ans_t2d1 = Dict{Union{Symbol,Function},Number}(:max => maximum(one_dim), 
-                                                        :mean => mean(one_dim), 
-                                                        :min => minimum(one_dim),
-                                                        :quantile_1 => quantile(one_dim,0.25),
-                                                        :median => median(one_dim),
-                                                        :quantile_3 => quantile(one_dim,0.75))
 
-        ans_t2d2 = Dict{Union{Symbol,Function},Number}(:max => maximum(two_dim), 
-                                                        :mean => mean(two_dim), 
-                                                        :min => minimum(two_dim),
-                                                        :median => median(two_dim))
+        ans_t2d1 = Dict{Union{Symbol,Function},Number}(
+            :max => maximum(one_dim),
+            :mean => mean(one_dim),
+            :min => minimum(one_dim),
+            :quantile_1 => quantile(one_dim,0.25),
+            :median => median(one_dim),
+            :quantile_3 => quantile(one_dim,0.75)
+        )
+
+        ans_t2d2 = Dict{Union{Symbol,Function},Number}(
+            :max => maximum(two_dim),
+            :mean => mean(two_dim),
+            :min => minimum(two_dim),
+            :median => median(two_dim)
+        )
 
         @test apply_descriptors(one_dim) == ans_t2d1
         @test apply_descriptors(two_dim) == ans_t2d2
@@ -56,12 +64,18 @@ rng = MersenneTwister(123)
 
     @testset "values and symbols test" begin
 
-        ans_t3d1 = Dict{Union{Symbol,Function},Number}(:max => maximum(one_dim), 
-                                                        :mean => mean(one_dim))
+        ans_t3d1 = Dict{Union{Symbol,Function},Number}(
+            :max => maximum(one_dim),
+            :mean => mean(one_dim)
+        )
 
-        ans_t3d2 = Dict{Union{Symbol,Function},Number}(:max => maximum(two_dim)) 
-                                                       
-        @test_logs (:warn,":noSymbol is not a valid symbol for dimension 1") apply_descriptors(one_dim,[:noSymbol]) 
+        ans_t3d2 = Dict{Union{Symbol,Function},Number}(
+            :max => maximum(two_dim)
+        )
+
+        @test_logs (:warn,":noSymbol is not a valid symbol for dimension 1")
+            apply_descriptors(one_dim,[:noSymbol])
+
         @test apply_descriptors(one_dim,sym_one) == ans_t3d1
         @test apply_descriptors(two_dim,sym_two) == ans_t3d2
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,6 +133,4 @@ rng = MersenneTwister(123)
 
     end
 
-    @test "apotropaic" == "apotropaic"
-
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,6 +115,12 @@ rng = MersenneTwister(123)
         @test apply_descriptors(two_dim, [:max], [minimum, mean]) == ans_t1d2
         @test apply_descriptors(two_dim, [minimum, mean], [:max]) == ans_t1d2
 
+        @test apply_descriptors(one_dim, [:max :max :max :max], [mean mean mean mean]) ==
+        Dict{Union{Symbol,Function},Number}(
+            :max => maximum(one_dim),
+            mean => mean(one_dim)
+        )
+
         # one symbol, multiple functions
         @test apply_descriptors(one_dim, :CO_HistogramAMI_even_2_5, [mean, median]) ==
         Dict{Union{Symbol,Function},Number}(
@@ -131,8 +137,9 @@ rng = MersenneTwister(123)
             mean => mean(one_dim)
         )
 
-        @test apply_descriptors(one_dim, [:max :max :max :max], [mean mean mean mean]) ==
+        @test apply_descriptors(one_dim, [:min :min :min :max], mean) ==
         Dict{Union{Symbol,Function},Number}(
+            :min => minimum(one_dim),
             :max => maximum(one_dim),
             mean => mean(one_dim)
         )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,5 +2,26 @@ using SoleFunctions
 using Test
 
 @testset "SoleFunctions.jl" begin
-    # Write your tests here.
+
+    test1 = [5,3,7,9,10,921.231,1,32,1323,12.3,12.2,212]
+    min = minimum(test1)
+    max = maximum(test1)
+    mean = mean(test1)
+    median = median(test1)
+    q_1 = quantile(test1, 0.25)
+    q_3 = quantile(test1, 0.75)
+    desc1 = Dict{Symbol, Real}(:min => min, :max => max, :mean => mean, :median => median, :quantile_1 => q_1, :quantile_3 => q_3)
+    
+    # general test (both Symbols and Functions)
+    @test_throws MethodError apply_descriptors( ["minimum", minimum, :min], [1,2,3])
+
+    # single Symbol test
+
+    # single Function test
+
+    # default test
+
+    #@test apply_descriptors(test1) == desc1
+
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -137,6 +137,13 @@ rng = MersenneTwister(123)
             mean => mean(one_dim)
         )
 
+        @test apply_descriptors(one_dim, [:max :max :min :min], mean) ==
+        Dict{Union{Symbol,Function},Number}(
+            :min => minimum(one_dim),
+            :max => maximum(one_dim),
+            mean => mean(one_dim)
+        )
+
     end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,22 +1,23 @@
 using SoleFunctions
-using Statistics
 using Random
-using Catch22
 using Test
 
 rng = MersenneTwister(123)
 
 @testset "SoleFunctions.jl" begin
 
-    one_dim = rand(Float64,10)
+    using Statistics
+    using Catch22
+
+    one_dim = rand(Float64,100)
     sym_one = [:max,:mean]
     func_one = [minimum]
 
-    two_dim = rand(Float64,10,2)
+    two_dim = rand(Float64,100,2)
     sym_two = [:max]
     func_two = [minimum,mean]
 
-    @testset "values symbol & function test" begin
+    @testset "values, symbols, functions test" begin
 
         ans_t1d1 = Dict{Union{Symbol,Function},Number}(
             :max => maximum(one_dim),
@@ -24,7 +25,7 @@ rng = MersenneTwister(123)
             minimum => minimum(one_dim)
         )
 
-        @test_throws UndefVarError apply_descriptors(one_dim,sym_one,[uselessFunc])
+        @test_throws UndefVarError apply_descriptors(one_dim,sym_one,[nonexistent_function])
         @test apply_descriptors(one_dim,sym_one,func_one) == ans_t1d1
         @test apply_descriptors(one_dim,func_one,sym_one) == ans_t1d1
 
@@ -47,7 +48,8 @@ rng = MersenneTwister(123)
             :min => minimum(one_dim),
             :quantile_1 => quantile(one_dim,0.25),
             :median => median(one_dim),
-            :quantile_3 => quantile(one_dim,0.75)
+            :quantile_3 => quantile(one_dim,0.75),
+            (getnames(catch22) .=> catch22(one_dim))...
         )
 
         ans_t2d2 = Dict{Union{Symbol,Function},Number}(
@@ -62,7 +64,7 @@ rng = MersenneTwister(123)
 
     end
 
-    @testset "values and symbols test" begin
+    @testset "values, symbols test" begin
 
         ans_t3d1 = Dict{Union{Symbol,Function},Number}(
             :max => maximum(one_dim),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,31 +1,69 @@
 using SoleFunctions
 using Statistics
+using random
+using Catch22
 using Test
 
+rng = MersenneTwister(123)
+
 @testset "SoleFunctions.jl" begin
-    test1 = [5,3,7,9,10,921.231,1,32,1323,12.3,12.2,212]
-    
-    min = minimum(test1)
-    max = maximum(test1)
-    media = mean(test1)
-    mediana = median(test1)
-    q_1 = quantile(test1, 0.25)
-    q_3 = quantile(test1, 0.75)
 
-    desc1 = Dict{Symbol, Real}(:mean => media, :min => min, :max => max, :median => mediana, :quantile_1 => q_1, :quantile_3 => q_3)
-    
-    # general test (both Symbols and Functions)
-    @test_throws MethodError apply_descriptors( ["minimum", minimum, :min], [1,2,3])
+    one_dim = rand(10,1)
+    sym_one = [:max,:mean]
+    func_one = [minimum]
 
-    # single Symbol test
+    two_dim = rand(10,2)
+    sym_two = [:max,:quantile_1]
+    func_two = [minimum,mean]
 
-    # single Function test
-    @test 
+    @testset "values symbol & function test" begin
 
-    # default test
-    @test apply_descriptors(test1) == desc1
+        ans_t1d1 = Dict{Union{Symbol,Function},Number}(:max => maximum(one_dim), 
+                                                        :mean => mean(one_dim), 
+                                                        minimum => minimum(one_dim))
 
-    #@test apply_descriptors(test1) == desc1
+        @test apply_descriptors(one_dim,sym_one,func_one) == ans_t1d1
+        @test apply_descriptors(one_dim,func_one,sym_one) == ans_t1d1
 
+
+        ans_t1d2 = Dict{Union{Symbol,Function},Number}(:max => maximum(two_dim), 
+                                                    :quantile_1 => quantile(one_dim,0.25), 
+                                                    minimum => minimum(one_dim),
+                                                    mean => mean(two_dim))
+
+        @test apply_descriptors(two_dim,sym_two,funct_two) == ans_t1d2
+        @test apply_descriptors(two_dim,func_two,sym_two) == ans_t1d2
+
+    @testset "values only test" begin
+        
+        ans_t2d1 = Dict{Union{Symbol,Function},Number}(:max => maximum(one_dim), 
+                                                        :mean => mean(one_dim), 
+                                                        :min => minimum(one_dim),
+                                                        :quantile_1 => quantile(one_dim,0.25),
+                                                        :median => median(one_dim),
+                                                        :quantile_3 => quantile(one_dim,0.75))
+
+        ans_t2d2 = Dict{Union{Symbol,Function},Number}(:max => maximum(two_dim), 
+                                                        :mean => mean(two_dim), 
+                                                        :min => minimum(two_dim),
+                                                        :median => median(two_dim))
+
+        @test apply_descriptors(one_dim) == and_t2d1
+        @test apply_descriptors(two_dim) ==ans_t2d2
+
+    end
+
+    @testset "values and symbols test" begin
+
+        ans_t3d1 = Dict{Union{Symbol,Function},Number}(:max => maximum(two_dim), 
+                                                        :mean => mean(two_dim),)
+
+        ans_t3d2 = Dict{Union{Symbol,Function},Number}(:max => maximum(two_dim), 
+                                                        :quantile_1 => quantile(two_dim,0.25),)
+        
+        @test apply_descriptors(one_dim,sym_one) == ans_t3d1
+        @test apply_descriptors(two_dim,sym_two) == and_t3d2
+
+    end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,8 +131,12 @@ rng = MersenneTwister(123)
             mean => mean(one_dim)
         )
 
-    end
+        @test apply_descriptors(one_dim, [:max :max :max :max], [mean mean mean mean]) ==
+        Dict{Union{Symbol,Function},Number}(
+            :max => maximum(one_dim),
+            mean => mean(one_dim)
+        )
 
-    @test "apotropaic" == "apotropaic"
+    end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using SoleFunctions
 using Statistics
-using random
+using Random
 using Catch22
 using Test
 
@@ -8,12 +8,12 @@ rng = MersenneTwister(123)
 
 @testset "SoleFunctions.jl" begin
 
-    one_dim = rand(10,1)
+    one_dim = rand(Float64,10)
     sym_one = [:max,:mean]
     func_one = [minimum]
 
-    two_dim = rand(10,2)
-    sym_two = [:max,:quantile_1]
+    two_dim = rand(Float64,10,2)
+    sym_two = [:max]
     func_two = [minimum,mean]
 
     @testset "values symbol & function test" begin
@@ -25,14 +25,14 @@ rng = MersenneTwister(123)
         @test apply_descriptors(one_dim,sym_one,func_one) == ans_t1d1
         @test apply_descriptors(one_dim,func_one,sym_one) == ans_t1d1
 
-
         ans_t1d2 = Dict{Union{Symbol,Function},Number}(:max => maximum(two_dim), 
-                                                    :quantile_1 => quantile(one_dim,0.25), 
-                                                    minimum => minimum(one_dim),
+                                                    minimum => minimum(two_dim),
                                                     mean => mean(two_dim))
 
-        @test apply_descriptors(two_dim,sym_two,funct_two) == ans_t1d2
+        @test apply_descriptors(two_dim,sym_two,func_two) == ans_t1d2
         @test apply_descriptors(two_dim,func_two,sym_two) == ans_t1d2
+        
+    end
 
     @testset "values only test" begin
         
@@ -48,21 +48,21 @@ rng = MersenneTwister(123)
                                                         :min => minimum(two_dim),
                                                         :median => median(two_dim))
 
-        @test apply_descriptors(one_dim) == and_t2d1
-        @test apply_descriptors(two_dim) ==ans_t2d2
+        @test apply_descriptors(one_dim) == ans_t2d1
+        @test apply_descriptors(two_dim) == ans_t2d2
 
     end
 
     @testset "values and symbols test" begin
 
-        ans_t3d1 = Dict{Union{Symbol,Function},Number}(:max => maximum(two_dim), 
-                                                        :mean => mean(two_dim),)
+        ans_t3d1 = Dict{Union{Symbol,Function},Number}(:max => maximum(one_dim), 
+                                                        :mean => mean(one_dim))
 
-        ans_t3d2 = Dict{Union{Symbol,Function},Number}(:max => maximum(two_dim), 
-                                                        :quantile_1 => quantile(two_dim,0.25),)
+        ans_t3d2 = Dict{Union{Symbol,Function},Number}(:max => maximum(two_dim)) 
+                                                        
         
         @test apply_descriptors(one_dim,sym_one) == ans_t3d1
-        @test apply_descriptors(two_dim,sym_two) == and_t3d2
+        @test apply_descriptors(two_dim,sym_two) == ans_t3d2
 
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,18 @@
 using SoleFunctions
+using Statistics
 using Test
 
 @testset "SoleFunctions.jl" begin
-
     test1 = [5,3,7,9,10,921.231,1,32,1323,12.3,12.2,212]
+    
     min = minimum(test1)
     max = maximum(test1)
-    mean = mean(test1)
-    median = median(test1)
+    media = mean(test1)
+    mediana = median(test1)
     q_1 = quantile(test1, 0.25)
     q_3 = quantile(test1, 0.75)
-    desc1 = Dict{Symbol, Real}(:min => min, :max => max, :mean => mean, :median => median, :quantile_1 => q_1, :quantile_3 => q_3)
+
+    desc1 = Dict{Symbol, Real}(:mean => media, :min => min, :max => max, :median => mediana, :quantile_1 => q_1, :quantile_3 => q_3)
     
     # general test (both Symbols and Functions)
     @test_throws MethodError apply_descriptors( ["minimum", minimum, :min], [1,2,3])
@@ -18,8 +20,10 @@ using Test
     # single Symbol test
 
     # single Function test
+    @test 
 
     # default test
+    @test apply_descriptors(test1) == desc1
 
     #@test apply_descriptors(test1) == desc1
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ rng = MersenneTwister(123)
                                                         :mean => mean(one_dim), 
                                                         minimum => minimum(one_dim))
 
+        @test_throws UndefVarError apply_descriptors(one_dim,sym_one,[uselessFunc])
         @test apply_descriptors(one_dim,sym_one,func_one) == ans_t1d1
         @test apply_descriptors(one_dim,func_one,sym_one) == ans_t1d1
 
@@ -59,8 +60,8 @@ rng = MersenneTwister(123)
                                                         :mean => mean(one_dim))
 
         ans_t3d2 = Dict{Union{Symbol,Function},Number}(:max => maximum(two_dim)) 
-                                                        
-        
+                                                       
+        @test_logs (:warn,":noSymbol is not a valid symbol for dimension 1") apply_descriptors(one_dim,[:noSymbol]) 
         @test apply_descriptors(one_dim,sym_one) == ans_t3d1
         @test apply_descriptors(two_dim,sym_two) == ans_t3d2
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,12 +131,8 @@ rng = MersenneTwister(123)
             mean => mean(one_dim)
         )
 
-        @test apply_descriptors(one_dim, [:max :max :max :max], [mean mean mean mean]) ==
-        Dict{Union{Symbol,Function},Number}(
-            :max => maximum(one_dim),
-            mean => mean(one_dim)
-        )
-
     end
+
+    @test "apotropaic" == "apotropaic"
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,20 +23,20 @@ rng = MersenneTwister(123)
     @testset "values only test" begin
 
         ans_t2d1 = Dict{Union{Symbol,Function},Number}(
-            :max => maximum(one_dim),
-            :mean => mean(one_dim),
-            :min => minimum(one_dim),
+            :maximum    => maximum(one_dim),
+            :mean       => mean(one_dim),
+            :minimum    => minimum(one_dim),
             :quantile_1 => quantile(one_dim,0.25),
-            :median => median(one_dim),
+            :median     => median(one_dim),
             :quantile_3 => quantile(one_dim,0.75),
             (getnames(catch22) .=> catch22(one_dim))...
         )
 
         ans_t2d2 = Dict{Union{Symbol,Function},Number}(
-            :max => maximum(two_dim),
-            :mean => mean(two_dim),
-            :min => minimum(two_dim),
-            :median => median(two_dim)
+            :maximum    => maximum(two_dim),
+            :mean       => mean(two_dim),
+            :minimum    => minimum(two_dim),
+            :median     => median(two_dim)
         )
 
         @test apply_descriptors(one_dim) == ans_t2d1
@@ -50,8 +50,8 @@ rng = MersenneTwister(123)
             maximum => maximum(one_dim)
         )
 
-        @test apply_descriptors(one_dim, :max) == Dict{Union{Symbol,Function},Number}(
-            :max => maximum(one_dim)
+        @test apply_descriptors(one_dim, :maximum) == Dict{Union{Symbol,Function},Number}(
+            :maximum => maximum(one_dim)
         )
 
         @test apply_descriptors(one_dim, :quantile_1) ==
@@ -66,8 +66,8 @@ rng = MersenneTwister(123)
 
         @test apply_descriptors(one_dim, :CO_HistogramAMI_even_2_5, mean) ==
         Dict{Union{Symbol,Function},Number}(
-            :CO_HistogramAMI_even_2_5 => CO_HistogramAMI_even_2_5(one_dim),
-            mean => mean(one_dim)
+            :CO_HistogramAMI_even_2_5   => CO_HistogramAMI_even_2_5(one_dim),
+            mean                        => mean(one_dim)
         )
 
     end
@@ -77,15 +77,15 @@ rng = MersenneTwister(123)
         @test_logs (:warn,":noSymbol is not a valid symbol for dimension 1")
             apply_descriptors(one_dim,[:no_symbol])
 
-        @test apply_descriptors(one_dim, [:max,:mean,:quantile_1]) ==
+        @test apply_descriptors(one_dim, [:maximum,:mean,:quantile_1]) ==
         Dict{Union{Symbol,Function},Number}(
-            :max => maximum(one_dim),
-            :mean => mean(one_dim),
+            :maximum    => maximum(one_dim),
+            :mean       => mean(one_dim),
             :quantile_1 => quantile(one_dim, 0.25)
         )
 
-        @test apply_descriptors(two_dim, [:max]) == Dict{Union{Symbol,Function},Number}(
-            :max => maximum(two_dim)
+        @test apply_descriptors(two_dim, [:maximum]) == Dict{Union{Symbol,Function},Number}(
+            :maximum => maximum(two_dim)
         )
 
     end
@@ -93,55 +93,55 @@ rng = MersenneTwister(123)
     @testset "values, symbol/s, function/s test" begin
 
         ans_t1d1 = Dict{Union{Symbol,Function},Number}(
-            :max => maximum(one_dim),
-            :mean => mean(one_dim),
+            :maximum    => maximum(one_dim),
+            :mean       => mean(one_dim),
             :quantile_1 => quantile(one_dim, 0.25),
-            minimum => minimum(one_dim)
+            minimum     => minimum(one_dim)
         )
 
         @test_throws UndefVarError apply_descriptors(
-            one_dim,[:max, :mean],[nonexistent_function]
+            one_dim,[:maximum, :mean],[nonexistent_function]
         )
 
-        @test apply_descriptors(one_dim,[:max, :mean, :quantile_1], [minimum]) == ans_t1d1
-        @test apply_descriptors(one_dim,[minimum],[:max, :mean, :quantile_1]) == ans_t1d1
+        @test apply_descriptors(one_dim,[:maximum, :mean, :quantile_1], [minimum]) == ans_t1d1
+        @test apply_descriptors(one_dim,[minimum],[:maximum, :mean, :quantile_1]) == ans_t1d1
 
         ans_t1d2 = Dict{Union{Symbol,Function},Number}(
-            :max => maximum(two_dim),
-            minimum => minimum(two_dim),
-            mean => mean(two_dim)
+            :maximum    => maximum(two_dim),
+            minimum     => minimum(two_dim),
+            mean        => mean(two_dim)
         )
 
-        @test apply_descriptors(two_dim, [:max], [minimum, mean]) == ans_t1d2
-        @test apply_descriptors(two_dim, [minimum, mean], [:max]) == ans_t1d2
+        @test apply_descriptors(two_dim, [:maximum], [minimum, mean]) == ans_t1d2
+        @test apply_descriptors(two_dim, [minimum, mean], [:maximum]) == ans_t1d2
 
-        @test apply_descriptors(one_dim, [:max :max :max :max], [mean mean mean mean]) ==
+        @test apply_descriptors(one_dim, [:maximum :maximum], [mean mean]) ==
         Dict{Union{Symbol,Function},Number}(
-            :max => maximum(one_dim),
-            mean => mean(one_dim)
+            :maximum    => maximum(one_dim),
+            mean        => mean(one_dim)
         )
 
         # one symbol, multiple functions
         @test apply_descriptors(one_dim, :CO_HistogramAMI_even_2_5, [mean, median]) ==
         Dict{Union{Symbol,Function},Number}(
-            :CO_HistogramAMI_even_2_5 => CO_HistogramAMI_even_2_5(one_dim),
-            mean => mean(one_dim),
-            median => median(one_dim)
+            :CO_HistogramAMI_even_2_5   => CO_HistogramAMI_even_2_5(one_dim),
+            mean                        => mean(one_dim),
+            median                      => median(one_dim)
         )
 
         # multiple symbols, one function
-        @test apply_descriptors(one_dim, [:max :CO_HistogramAMI_even_2_5], mean) ==
+        @test apply_descriptors(one_dim, [:maximum :CO_HistogramAMI_even_2_5], mean) ==
         Dict{Union{Symbol,Function},Number}(
-            :max => maximum(one_dim),
+            :maximum => maximum(one_dim),
             :CO_HistogramAMI_even_2_5 => CO_HistogramAMI_even_2_5(one_dim),
             mean => mean(one_dim)
         )
 
-        @test apply_descriptors(one_dim, [:max :max :min :min], mean) ==
+        @test apply_descriptors(one_dim, [:maximum :maximum :minimum :minimum], mean) ==
         Dict{Union{Symbol,Function},Number}(
-            :min => minimum(one_dim),
-            :max => maximum(one_dim),
-            mean => mean(one_dim)
+            :minimum    => minimum(one_dim),
+            :maximum    => maximum(one_dim),
+            mean        => mean(one_dim)
         )
 
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,31 +1,37 @@
 using SoleFunctions
 using Statistics
+using Random
 using Test
 
-@testset "SoleFunctions.jl" begin
-    test1 = [5,3,7,9,10,921.231,1,32,1323,12.3,12.2,212]
-    
-    min = minimum(test1)
-    max = maximum(test1)
-    media = mean(test1)
-    mediana = median(test1)
-    q_1 = quantile(test1, 0.25)
-    q_3 = quantile(test1, 0.75)
+rng = MersenneTwister(123)
 
-    desc1 = Dict{Symbol, Real}(:mean => media, :min => min, :max => max, :median => mediana, :quantile_1 => q_1, :quantile_3 => q_3)
-    
+@testset "SoleFunctions.jl" begin
+
+    # adimensional test input and expected output
+    t0 = 42
+    desc0 = Dict{Symbol, Real}(:mean => t0, :min => t0, :max => t0)
+
+    # one dimensional test input and expected output
+    t1 = randn(rng, 100)
+    desc1 = Dict{Symbol, Real}(:min => minimum(t1), :max => maximum(t1), :mean => mean(t1), :median => median(t1), :quantile_1 => quantile(t1, 0.25), :quantile_3 => quantile(t1, 0.75))
+
+    # two dimensional test input and expected output
+    t2 = randn(rng, 100, 2)
+    desc2 = Dict{Symbol, Real}(:min => minimum(t2), :max => maximum(t2), :mean => mean(t2), :median => median(t2))
+
     # general test (both Symbols and Functions)
     @test_throws MethodError apply_descriptors( ["minimum", minimum, :min], [1,2,3])
 
+    @test apply_descriptors([:mean, minimum, maximum, :quantile_1], t1) == Dict{Union{Function, Symbol}, Real}(:mean => mean(t1), minimum => minimum(t1), maximum => maximum(t1), :quantile_1 => quantile(t1, 0.25))
+    @test apply_descriptors([:mean], t2) == Dict{Symbol, Real}(:mean => mean(t2))
     # single Symbol test
 
     # single Function test
-    @test 
 
     # default test
-    @test apply_descriptors(test1) == desc1
-
-    #@test apply_descriptors(test1) == desc1
+    @test apply_descriptors(t0) == desc0
+    @test apply_descriptors(t1) == desc1
+    @test apply_descriptors(t2) == desc2
 
 
 end


### PR DESCRIPTION
Adimensional case removed from 𝒟 - apply a certain function to a single number is nonsense.
2D+ cases could be expanded with new functions: at the moment we only added catch22 to 𝒟[1].